### PR TITLE
Fix email form config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+EMAIL_USER=seuemail@gmail.com
+EMAIL_PASS=sua_senha
+EMAIL_DESTINO=destino@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Projeto institucional para apresentar os serviços da Exclusiva Maquetes.
 - Bootstrap 5
 
 ## Como visualizar
-Abra o arquivo `index.html` no navegador.
+1. Instale as dependências com `npm install`.
+2. Copie o arquivo `.env.example` para `.env` e preencha suas informações de e-mail.
+3. Inicie o servidor com `npm start`.
+4. Acesse `http://localhost:3000` no navegador.
 
 ## Autor
 [Eduardo Munis](https://github.com/eduardomunis)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "version": "1.0.0",
   "main": "script.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -22,8 +22,8 @@ app.post("/enviar-email", async (req, res) => {
   const transporter = nodemailer.createTransport({
     service: "gmail",
     auth: {
-      user: "eduardomunis10@gmail.com",
-      pass: "neqeimlptaophchr",
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
     },
   });
 


### PR DESCRIPTION
## Summary
- use env variables for nodemailer credentials
- rename README and add instructions to run server
- add start script in package.json
- add env example and ignore .env

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68489cdc0b10832388cfec3c8e7116a5