### PR TITLE
Integrate Resend for contact form

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-EMAIL_USER=seuemail@gmail.com
-EMAIL_PASS=neqeimlptaophchr
-EMAIL_DESTINO=eduardomunis10@gmail.com
+RESEND_API_KEY=sua_chave
+RESEND_FROM=seuemail@seudominio.com
+EMAIL_DESTINO=destino@example.com

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-EMAIL_USER=seuemail@gmail.com
-EMAIL_PASS=sua_senha
+# Chave da API da Resend
+RESEND_API_KEY=sua_chave
+# Endereço de remetente verificado na Resend
+RESEND_FROM=seuemail@seudominio.com
 EMAIL_DESTINO=destino@example.com

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Projeto institucional para apresentar os serviços da Exclusiva Maquetes.
 
 ## Como visualizar
 1. Instale as dependências com `npm install`.
-2. Copie o arquivo `.env.example` para `.env` e preencha suas informações de e-mail.
+2. Copie o arquivo `.env.example` para `.env` e informe sua chave da Resend, o e-mail remetente e o destinatário.
 3. Inicie o servidor com `npm start`.
 4. Acesse `http://localhost:3000` no navegador.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bootstrap": "^5.3.6",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "nodemailer": "^7.0.3"
+    "resend": "^0.9.0"
   },
   "name": "exclusiva-maquetes",
   "version": "1.0.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const nodemailer = require("nodemailer");
+const { Resend } = require("resend");
 const bodyParser = require("body-parser");
 require("dotenv").config();
 
@@ -10,6 +10,8 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(express.static("public"));
 
+const resend = new Resend(process.env.RESEND_API_KEY);
+
 app.post("/enviar-email", async (req, res) => {
   const { nome, email, mensagem } = req.body;
 
@@ -19,20 +21,13 @@ app.post("/enviar-email", async (req, res) => {
       .json({ sucesso: false, erro: "Campos obrigatórios não preenchidos" });
   }
 
-  const transporter = nodemailer.createTransport({
-    service: "gmail",
-    auth: {
-      user: process.env.EMAIL_USER,
-      pass: process.env.EMAIL_PASS,
-    },
-  });
-
   try {
-    await transporter.sendMail({
-      from: `"${nome}" <${email}>`,
+    await resend.emails.send({
+      from: process.env.RESEND_FROM,
       to: process.env.EMAIL_DESTINO,
       subject: "Mensagem do site",
-      text: mensagem,
+      text: `${mensagem}\n\nNome: ${nome}\nEmail: ${email}`,
+      reply_to: email,
     });
 
     return res.status(200).json({ sucesso: true });


### PR DESCRIPTION
## Summary
- switch contact form backend from Nodemailer to Resend
- update environment examples for Resend
- show Resend variables in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848d909f924832389ea11a30ddb932b